### PR TITLE
point at beginning of line in fluent syntax

### DIFF
--- a/testing.example/tests/testing/example/bank/BankTest.java
+++ b/testing.example/tests/testing/example/bank/BankTest.java
@@ -28,8 +28,8 @@ public class BankTest {
 		assertThat(newAccountId).isPositive();
 		assertThat(bankAccounts).
 			hasSize(1).
-			extracting(BankAccount::getId).
-				contains(newAccountId);
+			extracting(BankAccount::getId)
+				.contains(newAccountId);
 	}
 
 	@Test


### PR DESCRIPTION
Just a minor fix. In fluent syntax point at beginning of line just to be consistent with the whole code. I forgot to edit position of two previuous points in the same method